### PR TITLE
Revert back to miniconda instead of conda and update setup.cfg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           name: Running unit tests
           command: |
             # apt-get install -yqq make
-            source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
+            source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv_37
             make unittest
             mkdir /tmp/src/coverage
             mv /tmp/src/aroma/.coverage /tmp/src/coverage/.coverage.py37
@@ -131,7 +131,7 @@ jobs:
           command: |
             # apt-get install -yqq make
             source /etc/fsl/fsl.sh
-            source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
+            source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv_37
             make integration
             mkdir /tmp/src/coverage
             mv /tmp/src/aroma/.coverage /tmp/src/coverage/.coverage.integration37
@@ -154,7 +154,7 @@ jobs:
           name: Style check
           command: |
             # apt-get install -yqq make
-            source activate /opt/conda/envs/aroma_py37  # depends on makeenv37
+            source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv37
             make lint
       - store_artifacts:
           path: /tmp/data/lint
@@ -172,7 +172,7 @@ jobs:
           name: Build documentation
           command: |
             # apt-get install -yqq make
-            source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
+            source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv_37
             pip install sphinx_rtd_theme
             make -C docs html
       - store_artifacts:
@@ -192,7 +192,7 @@ jobs:
           name: Merge coverage files
           command: |
             # apt-get install -yqq curl
-            source activate /opt/conda/envs/aroma_py37  # depends on makeenv37
+            source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv37
             cd /tmp/src/coverage/
             coverage combine
             coverage xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = aroma
-url = https://github.com/Brainhack-Donostia/aroma
-author = BrainHack Donostia
-author_email = bhg-donostia@bcbl.eu
-maintainer = BrainHack Donostia
-maintainer_email = bhg-donostia@bcbl.eu
+url = https://github.com/ME-ICA/aroma
+author = tedana developers
+author_email = e.urunuela@bcbl.eu
+maintainer = tedana developers
+maintainer_email = e.urunuela@bcbl.eu
 description = "A port of the ICA-AROMA package."
 long_description = file:README.md
 long_description_content_type = text/x-md; charset=UTF-8


### PR DESCRIPTION
<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes none.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- This PR aims to fix the errors that #40 seems to have introduced regarding the conda environments.
- It also updates the setup.cfg file after migrating from Brainhack-Donostia left some attributes that were not updated.