### PR TITLE
[TST] Add Python 3.8/3.9 unit tests and use miniconda Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ jobs:
       - run:
           name: Generate environment
           command: |
+            apt-get update
             apt-get install -yqq make
             if [ ! -d /opt/conda/envs/aroma_py36 ]; then
               conda create -yq -n aroma_py36 python=3.6
@@ -200,6 +201,7 @@ jobs:
           name: Run integration tests
           no_output_timeout: 10m
           command: |
+            apt-get update
             apt-get install -yqq make
             source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
             make integration
@@ -223,6 +225,7 @@ jobs:
       - run:
           name: Style check
           command: |
+            apt-get update
             apt-get install -yqq make
             source activate /opt/conda/envs/aroma_py37  # depends on makeenv37
             make lint
@@ -241,6 +244,7 @@ jobs:
       - run:
           name: Build documentation
           command: |
+            apt-get update
             apt-get install -yqq make
             source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
             pip install sphinx_rtd_theme

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,9 +251,9 @@ jobs:
           path: /tmp/src/aroma/docs/_build/html
 
   merge_coverage:
-    working_directory: /tmp/src/aroma
     docker:
       - image: continuumio/miniconda3
+    working_directory: /tmp/src/aroma
     steps:
       - attach_workspace:
           at: /tmp
@@ -263,6 +263,7 @@ jobs:
       - run:
           name: Merge coverage files
           command: |
+            apt-get update
             apt-get install -yqq curl
             source activate aroma_py37  # depends on makeenv37
             cd /tmp/src/coverage/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,6 @@ jobs:
           name: Run integration tests
           no_output_timeout: 10m
           command: |
-            source /etc/fsl/fsl.sh
             source activate aroma_py36
             make integration
             mkdir /tmp/src/coverage
@@ -182,7 +181,6 @@ jobs:
           no_output_timeout: 10m
           command: |
             # apt-get install -yqq make
-            source /etc/fsl/fsl.sh
             source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv_37
             make integration
             mkdir /tmp/src/coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-py37-v2-{{ checksum "setup.cfg" }}
       - run:
           name: Generate environment
           command: |
@@ -58,7 +58,7 @@ jobs:
               pip install -e ".[test,doc]"
             fi
       - save_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-py37-v2-{{ checksum "setup.cfg" }}
           paths:
               - /opt/conda/envs/aroma_py37
 
@@ -69,7 +69,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-py37-v2-{{ checksum "setup.cfg" }}
       - run:
           name: Running unit tests
           command: |
@@ -196,7 +196,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-py37-v2-{{ checksum "setup.cfg" }}
       - run:
           name: Run integration tests
           no_output_timeout: 10m
@@ -221,13 +221,13 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-py37-v2-{{ checksum "setup.cfg" }}
       - run:
           name: Style check
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate aroma_py37  # depends on makeenv37
+            source activate aroma_py37  # depends on makeenv_37
             make lint
       - store_artifacts:
           path: /tmp/data/lint
@@ -240,14 +240,13 @@ jobs:
       - attach_workspace:  # get aroma
           at: /tmp
       - restore_cache:  # load environment
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-py37-v2-{{ checksum "setup.cfg" }}
       - run:
           name: Build documentation
           command: |
             apt-get update
             apt-get install -yqq make
             source activate aroma_py37  # depends on makeenv_37
-            pip install sphinx_rtd_theme
             make -C docs html
       - store_artifacts:
           path: /tmp/src/aroma/docs/_build/html
@@ -261,7 +260,7 @@ jobs:
           at: /tmp
       - checkout
       - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-py37-v2-{{ checksum "setup.cfg" }}
       - run:
           name: Merge coverage files
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,12 +233,11 @@ jobs:
           path: /tmp/data/lint
 
   build_docs:
-    working_directory: /tmp/src/aroma
     docker:
       - image: continuumio/miniconda3
+    working_directory: /tmp/src/aroma
     steps:
-      - attach_workspace:  # get aroma
-          at: /tmp
+      - checkout
       - restore_cache:  # load environment
           key: conda-py37-v2-{{ checksum "setup.cfg" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,29 +7,6 @@ orbs:
   codecov: codecov/codecov@1.0.5
 jobs:
 
-  makeenv_37:
-    docker:
-      - image: continuumio/miniconda3
-    working_directory: /tmp/src/aroma
-    steps:
-      - checkout
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-              - src/aroma
-      - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
-      - run:
-          name: Generate environment
-          command: |
-            conda create -yq -n aroma_py37 python=3.7
-            source activate /opt/miniconda-latest/envs/aroma_py37
-            pip install -e ".[test,doc]"
-      - save_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
-          paths:
-              - /opt/miniconda-latest/envs/aroma_py37
-
   unittest_36:
     docker:
       - image: continuumio/miniconda3
@@ -41,8 +18,9 @@ jobs:
       - run:
           name: Generate environment
           command: |
-            # apt-get install -yqq make
-            if [ ! -d /opt/miniconda-latest/envs/aroma_py36 ]; then
+            apt-get update
+            apt-get install -yqq make
+            if [ ! -d /opt/conda/envs/aroma_py36 ]; then
               conda create -yq -n aroma_py36 python=3.6
               source activate aroma_py36
               pip install -e ".[test]"
@@ -57,11 +35,32 @@ jobs:
       - save_cache:
           key: conda-py36-v1-{{ checksum "setup.cfg" }}
           paths:
-              - /opt/miniconda-latest/envs/aroma_py36
+              - /opt/conda/envs/aroma_py36
       - persist_to_workspace:
           root: /tmp
           paths:
               - src/coverage/.coverage.py36
+
+  makeenv_37:
+    docker:
+      - image: continuumio/miniconda3
+    working_directory: /tmp/src/aroma
+    steps:
+      - checkout
+      - restore_cache:
+          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+      - run:
+          name: Generate environment
+          command: |
+            if [ ! -d /opt/conda/envs/aroma_py37 ]; then
+              conda create -yq -n aroma_py37 python=3.7
+              source activate aroma_py37
+              pip install -e ".[test,doc]"
+            fi
+      - save_cache:
+          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          paths:
+              - /opt/conda/envs/aroma_py37
 
   unittest_37:
     docker:
@@ -74,11 +73,16 @@ jobs:
       - run:
           name: Running unit tests
           command: |
-            # apt-get install -yqq make
-            source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv_37
+            apt-get update
+            apt-get install -yqq make
+            source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
             make unittest
             mkdir /tmp/src/coverage
             mv /tmp/src/aroma/.coverage /tmp/src/coverage/.coverage.py37
+      - save_cache:
+          key: conda-py36-v1-{{ checksum "setup.cfg" }}
+          paths:
+              - /opt/conda/envs/aroma_py36
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -90,21 +94,29 @@ jobs:
     working_directory: /tmp/src/aroma
     steps:
       - checkout
+      - restore_cache:
+          key: conda-py38-v1-{{ checksum "setup.cfg" }}
       - run:
           name: Generate environment
           command: |
-            # apt-get install -yqq make
-            conda create -yq -n aroma_py38 python=3.8
-            source activate aroma_py38
-            pip install -e ".[test]"
+            apt-get update
+            apt-get install -yqq make
+            if [ ! -d /opt/conda/envs/aroma_py38 ]; then
+              conda create -yq -n aroma_py38 python=3.8
+              source activate aroma_py38
+              pip install -e ".[test]"
+            fi
       - run:
           name: Running unit tests
           command: |
-            # apt-get install -yqq make
-            source activate /opt/miniconda-latest/envs/aroma_py38
+            source activate aroma_py38
             make unittest
             mkdir /tmp/src/coverage
             mv /tmp/src/aroma/.coverage /tmp/src/coverage/.coverage.py38
+      - save_cache:
+          key: conda-py38-v1-{{ checksum "setup.cfg" }}
+          paths:
+              - /opt/conda/envs/aroma_py38
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -116,21 +128,29 @@ jobs:
     working_directory: /tmp/src/aroma
     steps:
       - checkout
+      - restore_cache:
+          key: conda-py39-v1-{{ checksum "setup.cfg" }}
       - run:
           name: Generate environment
           command: |
-            # apt-get install -yqq make
-            conda create -yq -n aroma_py39 python=3.9
-            source activate aroma_py39
-            pip install -e ".[test]"
+            apt-get update
+            apt-get install -yqq make
+            if [ ! -d /opt/conda/envs/aroma_py39 ]; then
+              conda create -yq -n aroma_py39 python=3.9
+              source activate aroma_py39
+              pip install -e ".[test]"
+            fi
       - run:
           name: Running unit tests
           command: |
-            # apt-get install -yqq make
-            source activate /opt/miniconda-latest/envs/aroma_py39
+            source activate aroma_py39
             make unittest
             mkdir /tmp/src/coverage
             mv /tmp/src/aroma/.coverage /tmp/src/coverage/.coverage.py39
+      - save_cache:
+          key: conda-py39-v1-{{ checksum "setup.cfg" }}
+          paths:
+              - /opt/conda/envs/aroma_py39
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -147,8 +167,8 @@ jobs:
       - run:
           name: Generate environment
           command: |
-            # apt-get install -yqq make
-            if [ ! -d /opt/miniconda-latest/envs/aroma_py36 ]; then
+            apt-get install -yqq make
+            if [ ! -d /opt/conda/envs/aroma_py36 ]; then
               conda create -yq -n aroma_py36 python=3.6
               source activate aroma_py36
               pip install -e ".[test]"
@@ -180,8 +200,8 @@ jobs:
           name: Run integration tests
           no_output_timeout: 10m
           command: |
-            # apt-get install -yqq make
-            source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv_37
+            apt-get install -yqq make
+            source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
             make integration
             mkdir /tmp/src/coverage
             mv /tmp/src/aroma/.coverage /tmp/src/coverage/.coverage.integration37
@@ -203,8 +223,8 @@ jobs:
       - run:
           name: Style check
           command: |
-            # apt-get install -yqq make
-            source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv37
+            apt-get install -yqq make
+            source activate /opt/conda/envs/aroma_py37  # depends on makeenv37
             make lint
       - store_artifacts:
           path: /tmp/data/lint
@@ -221,8 +241,8 @@ jobs:
       - run:
           name: Build documentation
           command: |
-            # apt-get install -yqq make
-            source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv_37
+            apt-get install -yqq make
+            source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
             pip install sphinx_rtd_theme
             make -C docs html
       - store_artifacts:
@@ -241,8 +261,8 @@ jobs:
       - run:
           name: Merge coverage files
           command: |
-            # apt-get install -yqq curl
-            source activate /opt/miniconda-latest/envs/aroma_py37  # depends on makeenv37
+            apt-get install -yqq curl
+            source activate /opt/conda/envs/aroma_py37  # depends on makeenv37
             cd /tmp/src/coverage/
             coverage combine
             coverage xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
+            source activate aroma_py37  # depends on makeenv_37
             make unittest
             mkdir /tmp/src/coverage
             mv /tmp/src/aroma/.coverage /tmp/src/coverage/.coverage.py37
@@ -203,7 +203,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
+            source activate aroma_py37  # depends on makeenv_37
             make integration
             mkdir /tmp/src/coverage
             mv /tmp/src/aroma/.coverage /tmp/src/coverage/.coverage.integration37
@@ -227,7 +227,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate /opt/conda/envs/aroma_py37  # depends on makeenv37
+            source activate aroma_py37  # depends on makeenv37
             make lint
       - store_artifacts:
           path: /tmp/data/lint
@@ -246,7 +246,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate /opt/conda/envs/aroma_py37  # depends on makeenv_37
+            source activate aroma_py37  # depends on makeenv_37
             pip install sphinx_rtd_theme
             make -C docs html
       - store_artifacts:
@@ -266,7 +266,7 @@ jobs:
           name: Merge coverage files
           command: |
             apt-get install -yqq curl
-            source activate /opt/conda/envs/aroma_py37  # depends on makeenv37
+            source activate aroma_py37  # depends on makeenv37
             cd /tmp/src/coverage/
             coverage combine
             coverage xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
 
   makeenv_37:
     docker:
-      - image: nipype/nipype
+      - image: continuumio/miniconda3
     working_directory: /tmp/src/aroma
     steps:
       - checkout
@@ -32,7 +32,7 @@ jobs:
 
   unittest_36:
     docker:
-      - image: nipype/nipype
+      - image: continuumio/miniconda3
     working_directory: /tmp/src/aroma
     steps:
       - checkout
@@ -65,7 +65,7 @@ jobs:
 
   unittest_37:
     docker:
-      - image: nipype/nipype
+      - image: continuumio/miniconda3
     working_directory: /tmp/src/aroma
     steps:
       - checkout
@@ -84,9 +84,61 @@ jobs:
           paths:
               - src/coverage/.coverage.py37
 
+  unittest_38:
+    docker:
+      - image: continuumio/miniconda3
+    working_directory: /tmp/src/aroma
+    steps:
+      - checkout
+      - run:
+          name: Generate environment
+          command: |
+            # apt-get install -yqq make
+            conda create -yq -n aroma_py38 python=3.8
+            source activate aroma_py38
+            pip install -e ".[test]"
+      - run:
+          name: Running unit tests
+          command: |
+            # apt-get install -yqq make
+            source activate /opt/miniconda-latest/envs/aroma_py38
+            make unittest
+            mkdir /tmp/src/coverage
+            mv /tmp/src/aroma/.coverage /tmp/src/coverage/.coverage.py38
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+              - src/coverage/.coverage.py38
+
+  unittest_39:
+    docker:
+      - image: continuumio/miniconda3
+    working_directory: /tmp/src/aroma
+    steps:
+      - checkout
+      - run:
+          name: Generate environment
+          command: |
+            # apt-get install -yqq make
+            conda create -yq -n aroma_py39 python=3.9
+            source activate aroma_py39
+            pip install -e ".[test]"
+      - run:
+          name: Running unit tests
+          command: |
+            # apt-get install -yqq make
+            source activate /opt/miniconda-latest/envs/aroma_py39
+            make unittest
+            mkdir /tmp/src/coverage
+            mv /tmp/src/aroma/.coverage /tmp/src/coverage/.coverage.py39
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+              - src/coverage/.coverage.py39
+
   integrationtest_36:
     docker:
-      - image: nipype/nipype
+      - image: continuumio/miniconda3
     working_directory: /tmp/src/aroma
     steps:
       - checkout
@@ -119,7 +171,7 @@ jobs:
 
   integrationtest_37:
     docker:
-      - image: nipype/nipype
+      - image: continuumio/miniconda3
     working_directory: /tmp/src/aroma
     steps:
       - checkout
@@ -144,7 +196,7 @@ jobs:
 
   style_check:
     docker:
-      - image: nipype/nipype
+      - image: continuumio/miniconda3
     working_directory: /tmp/src/aroma
     steps:
       - checkout
@@ -162,7 +214,7 @@ jobs:
   build_docs:
     working_directory: /tmp/src/aroma
     docker:
-      - image: nipype/nipype
+      - image: continuumio/miniconda3
     steps:
       - attach_workspace:  # get aroma
           at: /tmp
@@ -181,7 +233,7 @@ jobs:
   merge_coverage:
     working_directory: /tmp/src/aroma
     docker:
-      - image: nipype/nipype
+      - image: continuumio/miniconda3
     steps:
       - attach_workspace:
           at: /tmp
@@ -210,6 +262,8 @@ workflows:
       - unittest_37:
           requires:
             - makeenv_37
+      - unittest_38
+      - unittest_39
       - integrationtest_36
       - integrationtest_37:
           requires:
@@ -224,6 +278,8 @@ workflows:
           requires:
             - unittest_36
             - unittest_37
+            - unittest_38
+            - unittest_39
             - integrationtest_36
             - integrationtest_37
             - style_check

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >= 3.6
@@ -37,6 +38,7 @@ include_package_data = False
 [options.extras_require]
 doc =
     sphinx
+    sphinx_rtd_theme
 style =
     flake8 >=3.7
     flake8-docstrings >=1.5
@@ -44,7 +46,6 @@ test =
     pytest
     pytest-cov
     coverage
-    %(doc)s
     %(style)s
 all =
     %(doc)s


### PR DESCRIPTION
<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #51 and closes #49.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Switch from `nipype` Docker image to miniconda image for testing.
- Add unit test jobs for Python 3.8 and 3.9.
- Reorganize the CI config file a bit to be more like tedana's, because that's what I'm familiar with.
